### PR TITLE
Replace "aiohttp" with "requests"

### DIFF
--- a/src/leaderboard_scraper.py
+++ b/src/leaderboard_scraper.py
@@ -1,24 +1,28 @@
 from bs4 import BeautifulSoup
-import aiohttp
+import requests
 
-async def get_shit():
-    async with aiohttp.ClientSession() as session:
-        async with session.get("https://hyprd.mn/leaderboards") as r:
-            html = await r.text()
-            soup = BeautifulSoup(html, "html.parser")
-            t = soup.find('table', {'class:', 'leaderboard'})
 
-            # [[rank, username, hd_id, score, run_link], [.....]]
-            a = t.find_all('a')[0::2]
-            b = t.find_all('a')[1::2]
+def scrape_hyprdm_lb():
+    html = requests.get("https://hyprd.mn/leaderboards").text
+    soup = BeautifulSoup(html, "html.parser")
+    t = soup.find("table", {"class:", "leaderboard"})
 
-            lb = {}
-            # a is user id and username
-            # b is run id and score
-            for i in range(1000):
-                uid = a[i].attrs.get("href").rfind("/")
-                uid = a[i].attrs.get("href")[uid+1::]
-                rlink = b[i].attrs.get("href").rfind("/")
-                rlink = b[i].attrs.get("href")[rlink + 1::]
-                lb[uid] = {'rank': i+1, 'username': a[i].text, 'score': b[i].text, 'run_link': rlink }
-            return lb
+    # [[rank, username, hd_id, score, run_link], [.....]]
+    users: list[int, str] = t.find_all("a")[0::2]
+    ids: list[int, int] = t.find_all("a")[1::2]
+
+    lb = {}
+    # a is user id and username
+    # b is run id and score
+    for i in range(1000):
+        uid = users[i].attrs.get("href").rfind("/")
+        uid = users[i].attrs.get("href")[uid + 1 : :]
+        rlink = ids[i].attrs.get("href").rfind("/")
+        rlink = ids[i].attrs.get("href")[rlink + 1 : :]
+        lb[uid] = {
+            "rank": i + 1,
+            "username": users[i].text,
+            "score": ids[i].text,
+            "run_link": rlink,
+        }
+    return lb

--- a/src/pb_img_gen.py
+++ b/src/pb_img_gen.py
@@ -1,18 +1,19 @@
 from PIL import Image, ImageDraw, ImageFont
 import os
 
+
 def gen_pb(filename, rank, username, score):
-    #Draw a text on an Image, saves it, show it
-    Tinos = ImageFont.truetype('Tinos-Regular.ttf', 52)
+    # Draw a text on an Image, saves it, show it
+    Tinos = ImageFont.truetype("Tinos-Regular.ttf", 52)
     # sorath eye open
-    eye = Image.open('sorath_eye.png')
+    eye = Image.open("sorath_eye.png")
     # sorath eye copy
     eyecopy = eye.copy()
     # create image
-    image = Image.new(mode = "RGB", size = [1100, 84])
+    image = Image.new(mode="RGB", size=[1100, 84])
     draw = ImageDraw.Draw(image)
 
-    user_x_initial = 100 
+    user_x_initial = 100
     min_dist_rank_user = 28
     char_width = 24
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
-aiohttp
 bidict
 bs4
 discord
 Pillow
 python-dotenv
+requests


### PR DESCRIPTION
`aiohttp` requires adding a few extra scopes and could lead to keeping resources open after they are no longer needed. The `requests` library handles all of this for you.

Additional miscellaneous changes:
- formatter pass on `leaderboard_scraper.py` and `pb_img_gen.py`
- renamed `leaderboard_scraper::get_shit` to `leaderboard_scraper::scrape_hyprdm_lb`
- added a catch and notification for if a user isn't tracked yet in the `/stats` command; spawned thread would crash otherwise and lead to "the application did not respond"
- some minor code cleanup (removing unused variables, etc.)